### PR TITLE
Add additional conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ This will call `libreoffice` on the command line to convert the file to `pdf`.
 
 Currently supported transformations:
 
-- `SVG` to `PNG`/`SVG`: `umake file.pdf` (uses [inkscape](https://inkscape.org/) on the command line)
-- `DOCX`/`DOC`/`ODT` to `PDF`: `umake file.pdf` (uses libreoffice on the command line)
-- `MD` to `DOCX`: `umake file.docx` (uses [pandoc](https://pandoc.org/) on the command line)
+- `SVG` to `PNG`/`PDF`: `umake file.png` or `umake file.pdf` (uses [inkscape](https://inkscape.org/) on the command line)
+- `DOCX`/`DOC`/`ODT` to `PDF`: `umake file.pdf` (uses `libreoffice` on the command line)
+- `MD` to `DOCX`/`PDF`/`HTML`: `umake file.docx`, `umake file.pdf`, or `umake file.html` (uses [pandoc](https://pandoc.org/) on the command line)
+- `DOCX` to `MD`: `umake file.md` (uses `pandoc` on the command line)
+- `PNG` to `JPG` and `JPG` to `PNG`: `umake file.jpg` or `umake file.png` (uses `convert` from ImageMagick)
 
 

--- a/umake/converters.py
+++ b/umake/converters.py
@@ -41,11 +41,20 @@ class InkscapeConverter(SubprocessConverter):
 
 @register_converter
 class PandocConverter(SubprocessConverter):
-    _conversions = [('.docx', '.md')]
+    _conversions = [
+        ('.docx', '.md'),
+        ('.pdf', '.md'),
+        ('.html', '.md'),
+        ('.md', '.docx'),
+    ]
+
     def build_command(self, target, src):
-        return ['pandoc',
-                src,
-                '-o', target]
+        return [
+            'pandoc',
+            src,
+            '-o',
+            target,
+        ]
 
 @register_converter
 class XelateXConverter(SubprocessConverter):
@@ -86,4 +95,15 @@ class HeifConverter(SubprocessConverter):
                    ]
     def build_command(self, target, src):
         return ['heif-convert', src, target]
+
+
+@register_converter
+class ImageMagickConverter(SubprocessConverter):
+    _conversions = [
+        ('.jpg', '.png'),
+        ('.png', '.jpg'),
+    ]
+
+    def build_command(self, target, src):
+        return ['convert', src, target]
 

--- a/umake/tests/test_converters.py
+++ b/umake/tests/test_converters.py
@@ -7,4 +7,9 @@ def test_has_conversions():
 
     assert ('.jpeg', '.heic') in cs.registry
 
+    assert ('.jpg', '.png') in cs.registry
+    assert ('.png', '.jpg') in cs.registry
+    assert ('.md', '.docx') in cs.registry
+    assert ('.pdf', '.md') in cs.registry
+
     assert ('.docx', '.pdf') not in cs.registry


### PR DESCRIPTION
## Summary
- add more conversion targets like Markdown to PDF, HTML, PNG↔JPG
- support converting DOCX to Markdown
- document new conversions in README
- test that new conversions are registered

## Testing
- `pip install -e .`
- `pytest -q`
- `umake --supports docx pdf`


------
https://chatgpt.com/codex/tasks/task_e_687c02558c30833398b065fd1eb21efb